### PR TITLE
Fix installation on fresh OS X machines

### DIFF
--- a/universal-ctags.rb
+++ b/universal-ctags.rb
@@ -3,6 +3,7 @@ class UniversalCtags < Formula
   head 'https://github.com/universal-ctags/ctags.git'
   depends_on :autoconf
   depends_on :automake
+  depends_on 'pkg-config'
   conflicts_with 'ctags', :because => 'this formula installs the same executable as the ctags formula'
 
   def install


### PR DESCRIPTION
If pkg-config is not available, autogen.sh fails when trying to use the AC_DEFINE macro.

When attempting to `brew install universal-ctags --HEAD` without pkg-config installed, I get the following error output:

```
==> Installing universal-ctags from universal-ctags/universal-ctags
==> Cloning https://github.com/universal-ctags/ctags.git
Updating /Library/Caches/Homebrew/universal-ctags--git
==> Checking out branch master
==> ./autogen.sh
Last 15 lines from /Users/me/Library/Logs/Homebrew/universal-ctags/01.autogen.sh:
2016-01-30 09:12:33 -0800

./autogen.sh

autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force
autoreconf: configure.ac: tracing
autoreconf: configure.ac: not using Libtool
autoreconf: running: /usr/local/Cellar/autoconf/2.69/bin/autoconf --force
configure.ac:121: error: possibly undefined macro: AC_DEFINE
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: /usr/local/Cellar/autoconf/2.69/bin/autoconf failed with exit status: 1

READ THIS: https://git.io/brew-troubleshooting
If reporting this issue please do so at (not Homebrew/homebrew):
  https://github.com/universal-ctags/homebrew-universal-ctags/issues
```

By adding the pkg-config dependency, this error is resolved and I can successfully install universal-ctags.
