### PR TITLE
Fix deprecation message from homebrew

### DIFF
--- a/universal-ctags.rb
+++ b/universal-ctags.rb
@@ -1,8 +1,8 @@
 class UniversalCtags < Formula
   homepage 'https://github.com/universal-ctags/ctags'
   head 'https://github.com/universal-ctags/ctags.git'
-  depends_on :autoconf
-  depends_on :automake
+  depends_on 'autoconf'
+  depends_on 'automake'
   depends_on 'pkg-config'
   conflicts_with 'ctags', :because => 'this formula installs the same executable as the ctags formula'
 


### PR DESCRIPTION
The latest homebrew says below, so fixed it.

> Warning: Calling 'depends_on :autoconf' is deprecated!
> Use 'depends_on "autoconf"' instead.
