### PR TITLE
Address some deprecation warnings

### DIFF
--- a/universal-ctags.rb
+++ b/universal-ctags.rb
@@ -1,10 +1,10 @@
 class UniversalCtags < Formula
-  homepage 'https://github.com/universal-ctags/ctags'
-  head 'https://github.com/universal-ctags/ctags.git'
+  homepage "https://github.com/universal-ctags/ctags"
+  head "https://github.com/universal-ctags/ctags.git"
   depends_on "autoconf"
   depends_on "automake"
-  depends_on 'pkg-config'
-  conflicts_with 'ctags', :because => 'this formula installs the same executable as the ctags formula'
+  depends_on "pkg-config"
+  conflicts_with "ctags", :because => "this formula installs the same executable as the ctags formula"
 
   def install
     system "./autogen.sh"


### PR DESCRIPTION
I noticed a deprecation warning when running `brew outdated`:

```
Warning: Calling 'depends_on :autoconf' is deprecated!
Use 'depends_on "autoconf"' instead.
/usr/local/Library/Taps/universal-ctags/homebrew-universal-ctags/universal-ctags.rb:4:in `<class:UniversalCtags>'
Please report this to the universal-ctags/universal-ctags tap!

Warning: Calling 'depends_on :automake' is deprecated!
Use 'depends_on "automake"' instead.
/usr/local/Library/Taps/universal-ctags/homebrew-universal-ctags/universal-ctags.rb:5:in `<class:UniversalCtags>'
Please report this to the universal-ctags/universal-ctags tap!
```

and decided to fix some of the errors reported by `brew audit --strict --online universal-ctags`. There are still two errors:

```
universal-ctags/universal-ctags/universal-ctags:
  * Head-only (no stable download)
  * Formula should have a desc (Description).
```

but they're less-cosmetic, so I did not address them.
