### PR TITLE
Do not use deprecated `depends_on` syntax.

### DIFF
--- a/universal-ctags.rb
+++ b/universal-ctags.rb
@@ -1,8 +1,8 @@
 class UniversalCtags < Formula
   homepage 'https://github.com/universal-ctags/ctags'
   head 'https://github.com/universal-ctags/ctags.git'
-  depends_on :autoconf
-  depends_on :automake
+  depends_on 'autoconf'
+  depends_on 'automake'
   depends_on 'pkg-config'
   conflicts_with 'ctags', :because => 'this formula installs the same executable as the ctags formula'
 


### PR DESCRIPTION
Recent homebrew would emit the following diagnostic message when
encountering the deprecated syntax.

```
Warning: Calling 'depends_on :autoconf' is deprecated!
Use 'depends_on "autoconf"' instead.
/HOMEBREW/Library/Taps/universal-ctags/homebrew-universal-ctags/universal-ctags.rb:4:in `<class:UniversalCtags>'
Please report this to the universal-ctags/universal-ctags tap!

Warning: Calling 'depends_on :automake' is deprecated!
Use 'depends_on "automake"' instead.
/HOMEBREW/Library/Taps/universal-ctags/homebrew-universal-ctags/universal-ctags.rb:5:in `<class:UniversalCtags>'
Please report this to the universal-ctags/universal-ctags tap!
```
