### PR TITLE
Adding build option: jansson

### DIFF
--- a/universal-ctags.rb
+++ b/universal-ctags.rb
@@ -4,6 +4,7 @@ class UniversalCtags < Formula
   depends_on "autoconf"
   depends_on "automake"
   depends_on 'pkg-config'
+  depends_on "jansson" => :optional
   conflicts_with 'ctags', :because => 'this formula installs the same executable as the ctags formula'
 
   def install


### PR DESCRIPTION
If jansson is not specified as an (optional) dependency, PKG_CONFIG_PATH is not set correctly during the build process, resulting in no --output-format=json support.
