### PR TITLE
Calls to `system` pass an array of args

### DIFF
--- a/universal-ctags.rb
+++ b/universal-ctags.rb
@@ -10,7 +10,7 @@ class UniversalCtags < Formula
     system "./autogen.sh"
     system "./configure", "--prefix=#{prefix}"
     system "make"
-    system "make install"
+    system "make", "install"
   end
 
   def caveats


### PR DESCRIPTION
`brew audit` prefers `system "foo", "bar"` over `system "foo bar"`