### PR TITLE
 Enable iconv

### DIFF
--- a/universal-ctags.rb
+++ b/universal-ctags.rb
@@ -8,7 +8,7 @@ class UniversalCtags < Formula
 
   def install
     system "./autogen.sh"
-    system "./configure", "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}", "--enable-iconv"
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
Mac has icov installed by default.
If it doesn't hurt, how is it effective by default?
If there seems to be a problem, I'd like to give another PR again in Options.