### PR TITLE
Update deprecated `.undent` method

### DIFF
--- a/universal-ctags.rb
+++ b/universal-ctags.rb
@@ -33,7 +33,7 @@ class UniversalCtags < Formula
   end
 
   def caveats
-    <<-EOS.undent
+    <<~EOS
       Under some circumstances, emacs and ctags can conflict. By default,
       emacs provides an executable `ctags` that would conflict with the
       executable of the same name that ctags provides. To prevent this,
@@ -46,7 +46,7 @@ class UniversalCtags < Formula
   end
 
   test do
-    (testpath/"test.c").write <<-EOS.undent
+    (testpath/"test.c").write <<~EOS
       #include <stdio.h>
       #include <stdlib.h>
 


### PR DESCRIPTION
I noticed this deprecated function while attempting to get a list of my installed brew and cask apps via `brew bundle dump`.

Remove `.undent` in favor of the squiggly heredoc, a native Ruby
function since 2.3.