### PR TITLE
 Add --without-doc options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ sudo: false
 matrix:
   include:
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.3
       rvm: system
   fast_finish: true
 

--- a/universal-ctags.rb
+++ b/universal-ctags.rb
@@ -3,6 +3,7 @@ class UniversalCtags < Formula
   homepage "https://github.com/universal-ctags/ctags"
   head "https://github.com/universal-ctags/ctags.git"
   option "without-xml", "Compile without libxml2"
+  option "without-doc", "Compile without man pages"
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "pkg-config" => :build
@@ -16,11 +17,13 @@ class UniversalCtags < Formula
   end
 
   def install
-    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
-    ENV.prepend_path "PATH", libexec/"vendor/bin"
+    if !build.without? "doc"
+      ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
+      ENV.prepend_path "PATH", libexec/"vendor/bin"
 
-    resource("docutils").stage do
-      system "python", *Language::Python.setup_install_args(libexec/"vendor")
+      resource("docutils").stage do
+        system "python", *Language::Python.setup_install_args(libexec/"vendor")
+      end
     end
 
     opts = []


### PR DESCRIPTION
https://github.com/universal-ctags/homebrew-universal-ctags/issues/35 is Python problem.
But I think man pages aren't requred. So support `--without-doc`.