### PR TITLE
 Fix#48 Remove Python3 dependency and change recommended docutils

### DIFF
--- a/universal-ctags.rb
+++ b/universal-ctags.rb
@@ -6,7 +6,7 @@ class UniversalCtags < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "pkg-config" => :build
-  depends_on "docutils" => :build
+  depends_on "docutils" => :recommended
   depends_on "jansson" => :optional
   depends_on "libyaml" => :optional
   conflicts_with "ctags", :because => "this formula installs the same executable as the ctags formula"


### PR DESCRIPTION
Fix https://github.com/universal-ctags/homebrew-universal-ctags/issues/48 .
Docutils (man page) is recommended option.