### PR TITLE
universal-ctags: Fix build for Linux

### DIFF
--- a/universal-ctags.rb
+++ b/universal-ctags.rb
@@ -14,7 +14,7 @@ class UniversalCtags < Formula
   def install
     opts = []
     opts << "--disable-xml" if build.without? "xml"
-
+    opts << "PYTHON_EXTRA_LDFLAGS=#{`#{Formula["python@3.8"].opt_bin}/python3-config --ldflags`.chomp}" if OS.linux?
     system "./autogen.sh"
     system "./configure", "--prefix=#{prefix}", *opts
     system "make"


### PR DESCRIPTION
- On Linux (reproducible in the `homebrew/brew` Docker container) this was failing to build due to the following error:

```
==> Installing universal-ctags/universal-ctags/universal-ctags dependency: docutils
==> Pouring docutils-0.16_2.x86_64_linux.bottle.tar.gz
    /home/linuxbrew/.linuxbrew/Cellar/docutils/0.16_2: 790 files, 8.6MB
==> Installing universal-ctags/universal-ctags/universal-ctags --HEAD
==> ./autogen.sh
==> ./configure --prefix=/home/linuxbrew/.linuxbrew/Cellar/universal-ctags/HEAD-62f0144
==> make
Last 15 lines from /root/.cache/Homebrew/Logs/universal-ctags/03.make:
  CC       main/libctags_a-debug.o
  CC       main/readtags-mio.o
  CC       main/mini_geany-mini-geany.o
RST2MAN    man/ctags.1
RST2MAN    man/readtags.1
/home/linuxbrew/.linuxbrew/Cellar/docutils/0.16_2/libexec/bin/python3.8: error while loading shared libraries: libpython3.8.so.1.0: cannot open shared object file: No such file or directory
RST2MAN    man/tags.5
make[1]: *** [Makefile:5960: man/readtags.1] Error 127
make[1]: *** Waiting for unfinished jobs....
/home/linuxbrew/.linuxbrew/Cellar/docutils/0.16_2/libexec/bin/python3.8: error while loading shared libraries: libpython3.8.so.1.0: cannot open shared object file: No such file or directory
make[1]: *** [Makefile:5960: man/ctags.1] Error 127
/home/linuxbrew/.linuxbrew/Cellar/docutils/0.16_2/libexec/bin/python3.8: error while loading shared libraries: libpython3.8.so.1.0: cannot open shared object file: No such file or directory
make[1]: *** [Makefile:5962: man/tags.5] Error 127
make[1]: Leaving directory '/tmp/universal-ctags-20200628-19191-titkke'
make: *** [Makefile:1304: all] Error 2
```

- This should avoid `--without-docutils` becoming a common flag that [users need to specify](https://github.com/universal-ctags/homebrew-universal-ctags/commit/057a72691574ab09d500bf15ac6ba625c8a5c74d).

---

- Thanks for maintaining this formula and `universal-ctags` as software!
